### PR TITLE
refactor(Promises) Remove bluebird - migrate to native Promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "url": "https://github.com/gabrielboliveira/tracking-correios/issues"
   },
   "dependencies": {
-    "bluebird": "^3.7.2",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.20",
     "mock": "^0.1.1",

--- a/src/services/correios.js
+++ b/src/services/correios.js
@@ -1,9 +1,4 @@
-'use strict'
-
-const Promise = require("bluebird")
-
 const fetch = require('isomorphic-fetch')
-fetch.Promise = Promise
 
 const _extend = require('lodash/assignIn')
 const _get = require('lodash/get')
@@ -33,7 +28,7 @@ function fetchTracking (objects, configParams) {
         function fetchFromCorreios (objects) {
             let callsChunked = _chunk(objects, configParams.limit)
 
-            return Promise.map(callsChunked, fetchFromAPI)
+            return Promise.all(callsChunked.map(fetchFromAPI))
         }
 
         function fetchFromAPI (objects) {

--- a/src/track.js
+++ b/src/track.js
@@ -1,7 +1,3 @@
-'use strict'
-
-const Promise = require("bluebird")
-
 const _filter = require('lodash/filter')
 const _extend = require('lodash/assignIn')
 const _difference = require('lodash/difference')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,11 +1028,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
   integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
 
-bluebird@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
-  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
-
 brace-expansion@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"


### PR DESCRIPTION
This removes the bluebird library and migrates to using the native Promise library that is good enough for this package usage.